### PR TITLE
Add offset= to man page

### DIFF
--- a/fusefat.1
+++ b/fusefat.1
@@ -24,6 +24,9 @@ print version
 .TP
 \fB\-o\fR rw+
 enable read-write mount (\fBEXPERIMENTAL\fR)
+.TP
+\fB\-o\fR offset=\fIN\fR
+byte position of the start of the filesystem
 .SS "FUSE options:"
 
 .TP


### PR DESCRIPTION
Adding it to the `--help` output appears to be more complicated, as it's currently handled by fuse_main.